### PR TITLE
Have process_tx return time of broadcast

### DIFF
--- a/txCast.py
+++ b/txCast.py
@@ -105,8 +105,10 @@ def process_tx(i):
 
     renew_tor_ip()  # Renew tor IP address
     push_tx(next_broadcast_tx)
+    
+    push_time = datetime.now()
 
-    return current_time
+    return push_time
 
 
 def process_all():


### PR DESCRIPTION
Currently, `process_tx` will return the time before the it `sleep`s, with this change it will return the time of the broadcast