### PR TITLE
Adds hidden service selection

### DIFF
--- a/JS/functions.js
+++ b/JS/functions.js
@@ -135,7 +135,8 @@ function countdown() { // Count Down to next broadcast time
 
 function checkNextTime(){ // Check if next broadcast time has elapsed
   if (remainingms < 0){
-    pushTx(txList_remaining[0]);                      // Broadcast Transaction
+    let theService = document.getElementById("onion").value; 
+    pushTx(theService, txList_remaining[0]);                      // Broadcast Transaction
     timeList_processed.push(timeList_remaining[0]);   // Add first element of remaining time list
     txList_processed.push(txList_remaining[0]);       // Add first element of remaining tx list
     timeList_remaining.shift();  // Remove first element of remaining time list
@@ -176,9 +177,9 @@ function loop(){
   }, 500);                  // Note: May want to randomise to reduce data leak
 }
 
-function pushTx(tx){// Broadcast Transaction via Tor
-  url = "http://localhost:3100/push?tx=" + tx
-  let response = fetch(url, {  // Somehow pass pushURL to the server as an input
+function pushTx(service, tx){// Broadcast Transaction via Tor
+  url = "http://localhost:3100/push?service="+service+"&tx=" + tx;
+  let response = fetch(url, {  
     method: 'GET',
   });
 }

--- a/JS/index.html
+++ b/JS/index.html
@@ -29,8 +29,8 @@
 
 		<select id="onion">
 			<option value="None" selected>-- Select --</option>
-			<option value="http://explorerzydxu5ecjrkwceayqybizmpjjznk5izmitf2modhcusuqlid.onion/testnet/api/tx">Blockstream</option>
-			<option value="http://mempoolhqx4isw62xs7abwphsq7ldayuidyx2v2oethdhhj6mlo2r6ad.onion/testnet/api/tx">Mempool</option>
+			<option value="blockstream">Blockstream</option>
+			<option value="mempool">Mempool</option>
 		</select>
 
 

--- a/JS/server.js
+++ b/JS/server.js
@@ -7,7 +7,12 @@ tr.setTorAddress("127.0.0.1", 9050); // "127.0.0.1" and 9050 by default
 
 app.get("/push", (req, res, next) => { // Somehow pass pushURL from the functions.js script
   let theTx = req.query.tx;
-
+  let theService = req.query.service;
+  if (theService === 'mempool') {
+    var pushUrl = 'http://mempoolhqx4isw62xs7abwphsq7ldayuidyx2v2oethdhhj6mlo2r6ad.onion/testnet/api/tx';
+  } else {
+    var pushUrl = 'http://explorerzydxu5ecjrkwceayqybizmpjjznk5izmitf2modhcusuqlid.onion/testnet/api/tx';
+  }
   tr.request({
     method: 'POST',
     url: pushUrl,


### PR DESCRIPTION
Passes hidden service name to pushTx function, express server declares pushUrl  value based on hidden service name passed to the endpoint. If no hidden service name is passed to the express server, it defaults to Blockstream's service.